### PR TITLE
fix: Neovim設定のタイポと一貫性を修正

### DIFF
--- a/vim/lua/keymaps.lua
+++ b/vim/lua/keymaps.lua
@@ -3,7 +3,7 @@
 ---------------------------------------
 
 local map = vim.api.nvim_set_keymap
-local opts = { noremap = true, silent = false }
+local opts = { noremap = true, silent = true }
 
 vim.g.mapleader = ' '
 

--- a/vim/lua/options.lua
+++ b/vim/lua/options.lua
@@ -66,7 +66,7 @@ vim.opt.spell = false
 vim.opt.spelllang = { 'en_us' }
 
 -- 組み合わせキー入力のタイムアウト
-vim.o.timeoutlen = 700
+opt.timeoutlen = 700
 
 -- signcolumnを常に表示
-vim.o.signcolumn = 'yes'
+opt.signcolumn = 'yes'

--- a/vim/lua/plugins/blink-cmp.lua
+++ b/vim/lua/plugins/blink-cmp.lua
@@ -74,14 +74,15 @@ return {
     -- when the Rust fuzzy matcher is not available, by using `implementation = "prefer_rust"`
     --
     -- See the fuzzy documentation for more information
-    fuzzy = { implementation = "prefer_rust_with_warning" }
-  },
-  opts_extend = { "sources.default" },
-  cmdline = {
-    completion = {
-      menu = {
-        auto_show = true
+    fuzzy = { implementation = "prefer_rust_with_warning" },
+
+    cmdline = {
+      completion = {
+        menu = {
+          auto_show = true
+        }
       }
     }
-  }
+  },
+  opts_extend = { "sources.default" }
 }

--- a/vim/lua/plugins/nvim-tree.lua
+++ b/vim/lua/plugins/nvim-tree.lua
@@ -5,7 +5,7 @@ return {
     "nvim-tree/nvim-web-devicons",
   },
   lazy = false,
-  prioerity = 1000,
+  priority = 1000,
   keys = {
       { "<Leader>ee", "<cmd>NvimTreeToggle<CR>" },
       { "<Leader>ef", "<cmd>NvimTreeFindFile<CR>" },

--- a/vim/lua/plugins/nvim-treesitter.lua
+++ b/vim/lua/plugins/nvim-treesitter.lua
@@ -20,7 +20,6 @@ return {
                 "bash",
                 "regex",
             },
-            sync_install = true,
             auto_install = false,
             highlight = { enable = true },
             indent = { enable = true },

--- a/vim/lua/plugins/telescope.lua
+++ b/vim/lua/plugins/telescope.lua
@@ -16,16 +16,6 @@ return {
     },
     config = function()
         local actions = require("telescope.actions")
-        local telescopeConfig = require("telescope.config")
-
-        -- Clone the default Telescope configuration
-        local vimgrep_arguments = { unpack(telescopeConfig.values.vimgrep_arguments) }
-
-        -- I want to search in hidden/dot files.
-        table.insert(vimgrep_arguments, "--hidden")
-        -- I don't want to search in the `.git` directory.
-        table.insert(vimgrep_arguments, "--glob")
-        table.insert(vimgrep_arguments, "!**/.git/*")
 
         require("telescope").setup{
             defaults = {
@@ -38,8 +28,18 @@ return {
                     },
                 },
                 path_display = { "smart" },
-                -- `hidden = true` is not supported in text grep commands.
-                vimgrep_arguments = vimgrep_arguments,
+                vimgrep_arguments = {
+                    "rg",
+                    "--color=never",
+                    "--no-heading",
+                    "--with-filename",
+                    "--line-number",
+                    "--column",
+                    "--smart-case",
+                    "--hidden",
+                    "--glob",
+                    "!**/.git/*",
+                },
             },
             pickers = {
                 find_files = {


### PR DESCRIPTION
- nvim-tree.lua: prioerity → priority のタイポ修正
- keymaps.lua: silent = true に統一
- options.lua: vim.o → opt に統一
- telescope.lua: vimgrep_argumentsを直接定義に簡略化
- nvim-treesitter.lua: 不要なsync_installを削除

https://claude.ai/code/session_01XzZQHK8D2cDaWBk6nD8Wme